### PR TITLE
Fix segfaults in #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This will generate two result files: `Job ID_classifications.tsv` and `Job ID_re
 2. Read ID
 3. Taxonomy identifier
 4. Effective read length
-5. DNA level identitiy score
+5. DNA level identity score
 6. Amino-acid level identity score
 7. Total Hamming distance
 8. Classification Rank
@@ -138,9 +138,9 @@ Next, the steps for creating a database based on NCBI or GTDB taxonomy are descr
 ##### GTDB taxonomy
   
   Follow two steps below to generate GTDB taxonomy and accession2taxid file.
-  * Requirements: You need assembly FASTA files whose file name (or path) include the assembly accession.  
+  * Requirements: You need assembly FASTA files whose file name (or path) includes the assembly accession.  
     If you downloaded assemblies using [ncbi-genome-download](https://github.com/kblin/ncbi-genome-download), you probably don't have to care about it.  
-    The regular experssion of assembly accession is (GC[AF]_[0-9].[0-9])
+    The regular expression of assembly accessions is (GC[AF]_[0-9].[0-9])
     
   ```
   # 1. 

--- a/src/commons/Classifier.cpp
+++ b/src/commons/Classifier.cpp
@@ -158,7 +158,7 @@ void Classifier::startClassify(const LocalParameters &par) {
     size_t currentKmerCnt = 0;
     size_t seqCnt = 0;
     if (par.seqMode == 1 || par.seqMode == 3) {
-        queryFile = mmapData<char>(queryPath_1.c_str());
+        queryFile = mmapData<char>(queryPath_1.c_str(), 2); // mmap readonly
         madvise(queryFile.data, queryFile.fileSize, MADV_SEQUENTIAL);
 
         // Get start and end positions of each read
@@ -482,7 +482,7 @@ void Classifier::linearSearchParallel(QueryKmer *queryKmerList, size_t &queryKme
     stat(targetDiffIdxFileName.c_str(), &diffIdxFileSt);
     size_t numOfDiffIdx = diffIdxFileSt.st_size / sizeof(uint16_t);
 
-    struct MmapedData<DiffIdxSplit> diffIdxSplits = mmapData<DiffIdxSplit>(diffIdxSplitFileName.c_str());
+    struct MmapedData<DiffIdxSplit> diffIdxSplits = mmapData<DiffIdxSplit>(diffIdxSplitFileName.c_str(), 3);
 
     cout << "Comparing qeury and reference metamers..." << endl;
 


### PR DESCRIPTION
I was able to track down the issue underlying the segfaults reported by me in #10; in both cases,
wrong `mmap()` usage was the culprit, assuming that both input as well as database files would
always be writable by the user executing Metabuli.

I switched the mapping of the input FASTA file to a readonly mapping, and introduced a new
`mode = 3` for `mmapData` with `MAP_PRIVATE` to be used with database files, so in-memory
changes aren't persisted to disk.