### PR TITLE
Switch to ordered map for reproducible outputs

### DIFF
--- a/src/commons/common.h
+++ b/src/commons/common.h
@@ -34,7 +34,7 @@ struct Query{
     bool newSpecies; // 36 byte
 
     std::string name;
-    std::unordered_map<TaxID,int> taxCnt; // 8 byte per element
+    std::map<TaxID,int> taxCnt; // 8 byte per element
 
     bool operator==(int id) const { return queryId == id;}
 


### PR DESCRIPTION
Hi,

as mentioned in https://github.com/steineggerlab/Metabuli/issues/12#issuecomment-1587418059 - switching
to an ordered map here makes sure the `_classification.tsv` output file is identical between runs (with same 
parameters).