### PR TITLE
add --match-per-kmer option in classify workflow

### DIFF
--- a/src/commons/Classifier.cpp
+++ b/src/commons/Classifier.cpp
@@ -136,8 +136,7 @@ void Classifier::startClassify(const LocalParameters &par) {
     check.close();
 
     // Calculate maximum number of k-mers for each iteration.
-    size_t maxNumOfKmer = 0;
-    size_t matchPerKmer = 4;
+    size_t matchPerKmer = par.matchPerKmer;
     size_t c = sizeof(QueryKmer) + matchPerKmer * sizeof(Match);
     size_t ram_threads = ((size_t) par.ramUsage * (size_t) 1024 * 1024 * 1024)
                             - ((size_t) 134217728 * (size_t) par.threads);

--- a/src/commons/LocalParameters.cpp
+++ b/src/commons/LocalParameters.cpp
@@ -209,13 +209,21 @@ LocalParameters::LocalParameters() :
                      typeid(int),
                      (void *) &coverageCol,
                      ""),
+        MATCH_PER_KMER(MATCH_PER_KMER_ID,
+                       "--match-per-kmer",
+                       "Number of matches per query k-mer",
+                       "Number of matches per query k-mer. Larger values assign more memory for storing k-mer matches.",
+                       typeid(int),
+                       (void *) &matchPerKmer,
+                       ""),
         PRINT_COLUMNS(PRINT_COLUMNS_ID,
                       "--print-columns",
                       "CSV of column numbers to be printed",
                       "CSV of column numbers to be printed",
                       typeid(std::string),
                       (void *) &printColumns,
-                      "") {
+                      "")
+  {
     //add_to_library
 
     // build

--- a/src/commons/LocalParameters.cpp
+++ b/src/commons/LocalParameters.cpp
@@ -259,6 +259,7 @@ LocalParameters::LocalParameters() :
     classify.push_back(&MIN_CONS_CNT_EUK);
     classify.push_back(&PARAM_MASK_RESIDUES);
     classify.push_back(&PARAM_MASK_PROBABILTY);
+    classify.push_back(&MATCH_PER_KMER);
 
 
     //updateTargetDB

--- a/src/commons/LocalParameters.h
+++ b/src/commons/LocalParameters.h
@@ -54,6 +54,7 @@ public:
     PARAMETER(MAX_GAP)
     PARAMETER(MIN_CONS_CNT)
     PARAMETER(MIN_CONS_CNT_EUK)
+    PARAMETER(MATCH_PER_KMER)
 
     // DB build parameters
     PARAMETER(LIBRARY_PATH)
@@ -92,6 +93,7 @@ public:
     int printLog;
     int maxGap;
     int minConsCntEuk;
+    int matchPerKmer;
 
     // Database creation
     std::string tinfoPath;

--- a/src/workflow/classify.cpp
+++ b/src/workflow/classify.cpp
@@ -25,6 +25,7 @@ void setClassifyDefaults(LocalParameters & par){
     par.eukaryotaTaxId = 2759;
     par.maskMode = 0;
     par.maskProb = 0.9;
+    par.matchPerKmer = 4;
 }
 
 int classify(int argc, const char **argv, const Command& command)


### PR DESCRIPTION
Metabuli allocates memory for storing matches between query k-mers and reference k-mers.
As default, ```--match-per-kmer``` is 4, and enough memory to store four matches per one query k-mer is allocated.
Four matches per k-mer are enough in most cases. 
But we added an option to adjust the value because it is reported that four is not enough when input reads are populated with low-complexity sequences.
We already added ```--mask``` option in ```classify``` to prevent matches from low-complexity regions.
When you meet ```overflow!!!``` signal even with the ```--mask 1```, set ```--match-per-kmer``` > 4. 
