### PR TITLE
new parameter: --tie-ratio

### DIFF
--- a/src/commons/LocalParameters.cpp
+++ b/src/commons/LocalParameters.cpp
@@ -150,6 +150,13 @@ LocalParameters::LocalParameters() :
                     typeid(int),
                     (void *) &minSSMatch,
                     "^[0-9]+$"),
+        TIE_RATIO(TIE_RATIO_ID,
+                      "--tie-ratio",
+                      "Best * --tie-ratio is considered as a tie",
+                      "Best * --tie-ratio is considered as a tie",
+                      typeid(float),
+                      (void *) &tieRatio,
+                      "^0(\\.[0-9]+)?|1(\\.0+)?$"),
         LIBRARY_PATH(LIBRARY_PATH_ID,
                      "--library-path",
                      "Path to library where the FASTA files are stored",
@@ -314,6 +321,7 @@ LocalParameters::LocalParameters() :
     classify.push_back(&RAM_USAGE);
     classify.push_back(&MATCH_PER_KMER);
     classify.push_back(&ACCESSION_LEVEL);
+    classify.push_back(&TIE_RATIO);
     // classify.push_back(&MIN_SS_MATCH);
 
     // filter 

--- a/src/commons/LocalParameters.h
+++ b/src/commons/LocalParameters.h
@@ -56,6 +56,7 @@ public:
     PARAMETER(MIN_CONS_CNT_EUK)
     PARAMETER(MATCH_PER_KMER)
     PARAMETER(MIN_SS_MATCH)
+    PARAMETER(TIE_RATIO)
 
     // DB build parameters
     PARAMETER(LIBRARY_PATH)
@@ -104,6 +105,7 @@ public:
     int minConsCntEuk;
     int matchPerKmer;
     int minSSMatch;
+    float tieRatio;
 
     // Database creation
     std::string tinfoPath;

--- a/src/commons/Taxonomer.cpp
+++ b/src/commons/Taxonomer.cpp
@@ -27,6 +27,7 @@ Taxonomer::Taxonomer(const LocalParameters &par, NcbiTaxonomy *taxonomy) : taxon
     minConsCnt = par.minConsCnt;
     minConsCntEuk = par.minConsCntEuk;
     eukaryotaTaxId = par.eukaryotaTaxId;
+    tieRatio = par.tieRatio;
 
     if (par.seqMode == 1 || par.seqMode == 2) {
         denominator = 100;
@@ -300,7 +301,7 @@ TaxonScore Taxonomer::getBestSpeciesMatches(vector<Match> & speciesMatches,
 
     vector<TaxID> maxSpecies;
     for (auto & spScore : species2score) {
-        if (spScore.second > bestSpScore * 0.95) {
+        if (spScore.second >= bestSpScore * tieRatio) {
             maxSpecies.push_back(spScore.first);
         }
     }
@@ -397,7 +398,7 @@ TaxonScore Taxonomer::getBestSpeciesMatches(vector<Match> & speciesMatches,
     }
     vector<TaxID> maxSpecies;
     for (auto & spScore : species2score) {
-        if (spScore.second > bestSpScore * 0.95) {
+        if (spScore.second >= bestSpScore * tieRatio) {
             maxSpecies.push_back(spScore.first);
         }
     }

--- a/src/commons/Taxonomer.h
+++ b/src/commons/Taxonomer.h
@@ -61,6 +61,7 @@ private:
     int minConsCnt;
     int minConsCntEuk;
     int eukaryotaTaxId;
+    float tieRatio;
 
     // Internal
     int denominator;

--- a/src/workflow/classify.cpp
+++ b/src/workflow/classify.cpp
@@ -25,6 +25,7 @@ void setClassifyDefaults(LocalParameters & par){
     par.maskProb = 0.9;
     par.matchPerKmer = 4;
     par.accessionLevel = 0;
+    par.tieRatio = 0.95;
 }
 
 int classify(int argc, const char **argv, const Command& command)


### PR DESCRIPTION
When the best species score is A.
Scores >= (A * --tie-ratio) are considered as ties to the best score.
