### PR TITLE
Match analysis process became 200X faster in Windows OS

### DIFF
--- a/src/commons/KmerMatcher.h
+++ b/src/commons/KmerMatcher.h
@@ -14,6 +14,8 @@
 
 #define BufferSize 16'777'216 // 16 * 1024 * 1024 // 16 M
 
+#define AMINO_ACID_PART(kmer) ((kmer) & MARKER)
+
 // Input
 // 1. Query K-mers
 // 2. Reference K-mers
@@ -58,7 +60,7 @@ protected:
                                // search begins.
   };
 
-  size_t AminoAcidPart(size_t kmer) const { return (kmer)&MARKER; }
+  inline size_t AminoAcidPart(size_t kmer) const { return (kmer)&MARKER; }
 
   template <typename T>
   static void loadBuffer(FILE *fp, T *buffer, size_t &bufferIdx, size_t size) {
@@ -89,6 +91,7 @@ protected:
                   std::vector<uint8_t> &selectedHammingSum,
                   std::vector<uint16_t> &rightEndHammings,
                   std::vector<uint32_t> &selectedDnaEncodings,
+                  size_t & selectedMatchIdx,
                   uint8_t frame);
 
   virtual uint8_t getHammingDistanceSum(uint64_t kmer1, uint64_t kmer2);

--- a/src/commons/Taxonomer.cpp
+++ b/src/commons/Taxonomer.cpp
@@ -56,6 +56,9 @@ Taxonomer::Taxonomer(const LocalParameters &par, NcbiTaxonomy *taxonomy) : taxon
     linkedMatchValuesIdx.reserve(4096);
     match2depthScore.reserve(4096); 
 
+    match2path.reserve(4096);
+    start2bestPath.reserve(4096);
+
     // lowerRankClassification
     cladeCnt.reserve(4096);
 
@@ -471,9 +474,11 @@ void Taxonomer::getMatchPaths(const Match * matchList,
     if (taxonomy->IsAncestor(eukaryotaTaxId, speciesId)) {
         MIN_DEPTH = minConsCntEuk - 1;
     }
-
-    unordered_map<const Match *, MatchPath> match2path;
-    unordered_map<const Match *, MatchPath> start2bestPath;
+    
+    match2path.clear();
+    start2bestPath.clear();
+    // unordered_map<const Match *, MatchPath> match2path;
+    // unordered_map<const Match *, MatchPath> start2bestPath;
 
     if (frame < 3) { // Forward frame
         size_t curPosMatchStart = i;        

--- a/src/commons/Taxonomer.h
+++ b/src/commons/Taxonomer.h
@@ -147,10 +147,6 @@ public:
 
     bool isMatchPathOverlapped(const MatchPath & matchPath1, const MatchPath & matchPath2);
 
-    bool isMatchPathLinked(const MatchPath & matchPath1, const MatchPath & matchPath2);
-
-    void mergeMatchPaths(const MatchPath & source, MatchPath & target);
-
     void trimMatchPath(MatchPath & path1, const MatchPath & path2, int overlapLength);
 
     void filterRedundantMatches(const Match *matchList,
@@ -165,47 +161,6 @@ public:
     TaxonScore getBestSpeciesMatches(std::pair<size_t, size_t> & bestSpeciesRange,
                                      const Match *matchList, size_t end,
                                      size_t offset, int queryLength);
-    
-    // TaxonScore getBestGenusMatches_spaced(vector<Match> &matchesForMajorityLCA, const Match *matchList, size_t end, size_t offset,
-    //                                       int readLength1, int readLength2);
-    // TaxonScore getBestGenusMatches_spaced(vector<Match> &matchesForMajorityLCA, const Match *matchList, size_t end, size_t offset,
-    //                                       int readLength1);
-
-    TaxonScore scoreTaxon(vector<const Match *> &filteredMatches,
-                          TaxID taxId,
-                          int queryLength);
-
-    TaxonScore scoreTaxon(vector<const Match *> &filteredMatches,
-                          TaxID taxId,
-                          int readLength1,
-                          int readLength2);
-
-    void scoreGenus_ExtensionScore(vector<Match> &filteredMatches,
-                                   vector<vector<Match>> &matchesForEachGenus,
-                                   vector<float> &scoreOfEachGenus,
-                                   int readLength1, int readLength2);
-
-    TaxonScore chooseSpecies(const std::vector<Match> &matches,
-                             int queryLength,
-                             vector<TaxID> &species,
-                             unordered_map<TaxID, pair<int, int>> & speciesMatchRange);
-
-    TaxonScore chooseSpecies(const std::vector<Match> &matches,
-                             int read1Length,
-                             int read2Length,
-                             vector<TaxID> &species,
-                             unordered_map<TaxID, pair<int, int>> & speciesMatchRange);
-
-    TaxonScore scoreSpecies(const vector<Match> &matches,
-                            size_t begin,
-                            size_t end,
-                            int queryLength);
-
-    TaxonScore scoreSpecies(const vector<Match> &matches,
-                            size_t begin,
-                            size_t end,
-                            int queryLength,
-                            int queryLength2);
 
     TaxID lowerRankClassification(const unordered_map<TaxID, unsigned int> & taxCnt, TaxID speciesID, int queryLength);
 

--- a/src/commons/Taxonomer.h
+++ b/src/commons/Taxonomer.h
@@ -33,13 +33,23 @@ struct depthScore {
 };
 
 struct MatchPath {
-    MatchPath(int start, int end, float score, int hammingDist, const Match * startMatch, const Match * endMatch) :
-         start(start), end(end), score(score), hammingDist(hammingDist), startMatch(startMatch), endMatch(endMatch) {}
-    MatchPath() : start(0), end(0), score(0.f), hammingDist(0), startMatch(nullptr), endMatch(nullptr) {}
-    int start;
-    int end;
+    MatchPath(int start, int end, float score, int hammingDist, int depth, const Match * startMatch, const Match * endMatch) :
+         start(start), end(end), score(score), hammingDist(hammingDist), depth(depth), startMatch(startMatch), endMatch(endMatch) {}
+    MatchPath() : start(0), end(0), score(0.f), hammingDist(0), depth(0), startMatch(nullptr), endMatch(nullptr) {}
+    MatchPath(const Match * startMatch) 
+        : start(startMatch->qInfo.pos),
+          end(startMatch->qInfo.pos + 23),
+          score(startMatch->getScore()),
+          hammingDist(startMatch->hamming),
+          depth(1),
+          startMatch(startMatch),
+          endMatch(startMatch) {}
+    
+    int start;                // query coordinate
+    int end;                  // query coordinate
     float score;
     int hammingDist;
+    int depth;
     const Match * startMatch;
     const Match * endMatch;
 };
@@ -138,6 +148,12 @@ public:
                                   size_t end,
                                   vector<MatchPath> & matchPaths,
                                   TaxID speciesId);
+
+    void getMatchPaths(const Match * matchList,
+                       size_t start,
+                       size_t end,
+                       vector<MatchPath> & matchPaths,
+                       TaxID speciesId);                                  
     
     float combineMatchPaths(vector<MatchPath> & matchPaths,
                             size_t matchPathStart,

--- a/src/commons/Taxonomer.h
+++ b/src/commons/Taxonomer.h
@@ -110,9 +110,6 @@ private:
     vector<bool> connectedToNext;
     vector<MatchPath> localMatchPaths;
 
-    unordered_map<const Match *, MatchPath> match2path;
-    unordered_map<const Match *, MatchPath> start2bestPath;
-
     // lowerRankClassification
     unordered_map<TaxID, TaxonCounts> cladeCnt;
 
@@ -164,13 +161,7 @@ public:
                        size_t start,
                        size_t end,
                        vector<MatchPath> & matchPaths,
-                       TaxID speciesId);                                  
-
-    void getMatchPaths2(const Match * matchList,
-                       size_t start,
-                       size_t end,
-                       vector<MatchPath> & matchPaths,
-                       TaxID speciesId);  
+                       TaxID speciesId);                                    
 
     float combineMatchPaths(vector<MatchPath> & matchPaths,
                             size_t matchPathStart,

--- a/src/commons/Taxonomer.h
+++ b/src/commons/Taxonomer.h
@@ -52,6 +52,10 @@ struct MatchPath {
     int depth;
     const Match * startMatch;
     const Match * endMatch;
+
+    void printMatchPath() {
+        std::cout << start << " " << end << " " << score << " " << hammingDist << " " << depth << std::endl;
+    }
 };
 
 struct MatchBlock {
@@ -101,6 +105,10 @@ private:
     vector<const Match *> linkedMatchValues;
     vector<size_t> linkedMatchValuesIdx;
     unordered_map<const Match *, depthScore> match2depthScore;
+
+    // getMatchPaths
+    vector<bool> connectedToNext;
+    vector<MatchPath> localMatchPaths;
 
     unordered_map<const Match *, MatchPath> match2path;
     unordered_map<const Match *, MatchPath> start2bestPath;
@@ -157,7 +165,13 @@ public:
                        size_t end,
                        vector<MatchPath> & matchPaths,
                        TaxID speciesId);                                  
-    
+
+    void getMatchPaths2(const Match * matchList,
+                       size_t start,
+                       size_t end,
+                       vector<MatchPath> & matchPaths,
+                       TaxID speciesId);  
+
     float combineMatchPaths(vector<MatchPath> & matchPaths,
                             size_t matchPathStart,
                             vector<MatchPath> & combMatchPaths,

--- a/src/commons/Taxonomer.h
+++ b/src/commons/Taxonomer.h
@@ -102,6 +102,9 @@ private:
     vector<size_t> linkedMatchValuesIdx;
     unordered_map<const Match *, depthScore> match2depthScore;
 
+    unordered_map<const Match *, MatchPath> match2path;
+    unordered_map<const Match *, MatchPath> start2bestPath;
+
     // lowerRankClassification
     unordered_map<TaxID, TaxonCounts> cladeCnt;
 


### PR DESCRIPTION
- Fixed a bug in remainConsecutiveMatches
  - It will change results slightly due to corrected score calculation.
- Previously, a graph that connects consecutive matches is constructed first, and the graph is traversed to find the best combination of matches. Now, the optimal match combination is found directly. It is the main point of speeding up. 