### PR TITLE
Bitpacking TaxID index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Prerequisites
 *.d
 
+util/metabuli
+
 # Compiled Object files
 *.slo
 *.lo

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.d
 
 util/metabuli
+master_build
 
 # Compiled Object files
 *.slo

--- a/lib/fastq_utils/CMakeLists.txt
+++ b/lib/fastq_utils/CMakeLists.txt
@@ -6,4 +6,7 @@ add_library(fastq_utils
         fastq.h
 )
 
+find_package(ZLIB REQUIRED)
+target_link_libraries(fastq_utils PUBLIC ZLIB::ZLIB)
+
 set_target_properties(fastq_utils PROPERTIES COMPILE_FLAGS "${MMSEQS_CXX_FLAGS} -w" LINK_FLAGS "${MMSEQS_CXX_FLAGS} -w")

--- a/lib/fastq_utils/CMakeLists.txt
+++ b/lib/fastq_utils/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(fastq_utils
 )
 
 find_package(ZLIB REQUIRED)
-target_link_libraries(fastq_utils PUBLIC ZLIB::ZLIB)
+target_include_directories(fastq_utils PUBLIC ${ZLIB_INCLUDE_DIRS})
+target_link_libraries(fastq_utils PUBLIC ${ZLIB_LIBRARIES})
 
 set_target_properties(fastq_utils PROPERTIES COMPILE_FLAGS "${MMSEQS_CXX_FLAGS} -w" LINK_FLAGS "${MMSEQS_CXX_FLAGS} -w")

--- a/src/LocalCommandDeclarations.h
+++ b/src/LocalCommandDeclarations.h
@@ -24,6 +24,7 @@ extern int editNames(int argc, const char **argv, const Command& command);
 extern int createnewtaxalist(int argc, const char **argv, const Command& command);
 extern int classifiedRefiner(int argc, const char **argv, const Command& command);
 extern int validateDatabase(int argc, const char **argv, const Command& command);
+extern int compactInfoIndex(int argc, const char **argv, const Command& command);
 extern int printDeltaIdx(int argc, const char **argv, const Command& command); 
 extern int makeBenchmarkSet(int argc, const char **argv, const Command &command);
 extern int makeQuerySet(int argc, const char **argv, const Command &command);

--- a/src/MetabuliBase.cpp
+++ b/src/MetabuliBase.cpp
@@ -257,6 +257,13 @@ std::vector<Command> metabuliCommands = {
                 "<i: database directory>",
                 CITATION_SPACEPHARER,
                 {{"database directory", DbType::ACCESS_MODE_INPUT, DbType::NEED_DATA, &DbValidator::directory}}},
+        {"compact-info", compactInfoIndex, &localPar.compactInfoIndex, COMMAND_DATABASE_CREATION,
+                "Compact an existing database info index",
+                nullptr,
+                "Jaebeom Kim <jbeom0731@gmail.com>",
+                "<i: database directory>",
+                CITATION_SPACEPHARER,
+                {{"database directory", DbType::ACCESS_MODE_INPUT, DbType::NEED_DATA, &DbValidator::directory}}},
         {"inspect-db", inspect_db, &localPar.validateDatabase,COMMAND_EXPERT,
                 "Inspect a database",
                 nullptr,
@@ -362,5 +369,4 @@ std::vector<DatabaseDownload> externalDownloads = {
                 {}
         }
 };
-
 

--- a/src/commons/CMakeLists.txt
+++ b/src/commons/CMakeLists.txt
@@ -36,6 +36,7 @@ set(commons_source_files
 		commons/KmerScanner.h
 		commons/KmerScanner.cpp
 		commons/DeltaIdxReader.h
+		commons/InfoIndex.h
 		commons/MetamerPattern.h
 		commons/MetamerPattern.cpp
         PARENT_SCOPE)

--- a/src/commons/Classifier.cpp
+++ b/src/commons/Classifier.cpp
@@ -125,7 +125,7 @@ uint64_t Classifier::calculateBufferSize(
         1024 * 1024 * sizeof(Match) + // local match buffer 32 MB
         1024 * 1024 * 4 * sizeof(Kmer) +  // DeltaIdxReader::valueBuffer 64 MB
         1024 * 1024 * 4 * sizeof(uint16_t) +   // DeltaIdxReader::deltaBuffer 2 MB
-        1024 * 1024 * 4 * sizeof(uint32_t);    // DeltaIdxReader::infoBuffer 4 MB
+        1024 * 1024 * 4 * sizeof(uint32_t);    // DeltaIdxReader::InfoIndexReader byte budget
 
     size_t overhead = 128 * 1024 * 1024; // 128MB
     size_t queryListBytes = queryListSize * (sizeof(Query) + 150); //  104,857,600

--- a/src/commons/DeltaIdxReader.h
+++ b/src/commons/DeltaIdxReader.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <iostream>
 #include <cstdlib>
+#include <cstring>
+#include <memory>
 #include <unistd.h>
 #include <fcntl.h>
 
@@ -140,23 +142,173 @@ private:
     // To manage delta indices    
     size_t readBufferSize;
     ReadBuffer<uint16_t> deltaIdxBuffer;
-    // Reads either the legacy uint32 info stream or the packed final info file.
-    // The interface exposes logical IDs, so split offsets do not change.
-    InfoIndexReader infoReader;
+    InfoIndexMetadata infoMetadata;
+    bool infoIsPacked = false;
+    // Only one info buffer is active. Plain DBs keep the old direct TaxID
+    // pointer path; packed DBs decode from uint64 words.
+    std::unique_ptr<ReadBuffer<TaxID>> plainInfoBuffer;
+    std::unique_ptr<ReadBuffer<uint64_t>> packedInfoBuffer;
+    uint8_t packedIdBits = 32;
+    uint8_t packedValuesPerWord = 1;
+    uint64_t packedIdMask = UINT32_MAX;
+    uint64_t packedCurrentWord = 0;
+    uint8_t packedLane = 0;
+    size_t packedReadCount = 0;
     bool fileCompleted = false;
     bool valueBufferCompleted = false;
 
     void fillValueBuffer() {
-        for (; valueCnt < valueBufferSize; ++valueCnt) {
-            uint32_t taxId = 0;
-            if (unlikely(!infoReader.next(taxId))) {
-                fileCompleted = true;
-                break;
+        // Format is chosen once per refill, not once per ID. This keeps legacy
+        // uint32 databases on the same hot path they used before bitpacking.
+        if (unlikely(infoIsPacked)) {
+            switch (packedIdBits) {
+                case 8:  fillValueBufferPacked<8>(); break;
+                case 10: fillValueBufferPacked<10>(); break;
+                case 12: fillValueBufferPacked<12>(); break;
+                case 16: fillValueBufferPacked<16>(); break;
+                case 21: fillValueBufferPacked<21>(); break;
+                default: fillValueBufferPackedGeneric(); break;
             }
-            // ID retrieval is hidden behind InfoIndexReader; packed databases
-            // pay only one shift/mask per ID before the Kmer enters this buffer.
-            valueBuffer[valueCnt].tInfo.taxId = taxId;
+            return;
+        }
+        fillValueBufferPlain();
+    }
+
+    void fillValueBufferPlain() {
+        for (; valueCnt < valueBufferSize; ++valueCnt) {
+            if (unlikely(plainInfoBuffer->p == plainInfoBuffer->end)) {
+                size_t readCnt = plainInfoBuffer->loadBuffer();
+                if (readCnt == 0) {
+                    fileCompleted = true;
+                    break;
+                }
+            }
+            valueBuffer[valueCnt].tInfo.taxId = *plainInfoBuffer->p++;
             valueBuffer[valueCnt].value = getNextMetamer();
+        }
+    }
+
+    template <uint8_t ID_BITS>
+    void fillValueBufferPacked() {
+        static constexpr uint8_t VALUES_PER_WORD = InfoIndex::WORD_BITS / ID_BITS;
+        static constexpr uint64_t ID_MASK = (uint64_t{1} << ID_BITS) - 1;
+
+        while (valueCnt < valueBufferSize && packedReadCount < totalValueNum) {
+            if (unlikely(packedLane >= VALUES_PER_WORD)) {
+                if (unlikely(!loadPackedWord())) {
+                    break;
+                }
+            }
+
+            // Decode all remaining lanes from the current word before touching
+            // the packed input buffer again. ID_BITS is a compile-time constant
+            // in the common formats, so shifts and masks optimize well.
+            while (valueCnt < valueBufferSize &&
+                   packedLane < VALUES_PER_WORD &&
+                   packedReadCount < totalValueNum) {
+                valueBuffer[valueCnt].tInfo.taxId =
+                    static_cast<TaxID>((packedCurrentWord >> (packedLane * ID_BITS)) & ID_MASK);
+                valueBuffer[valueCnt].value = getNextMetamer();
+                ++valueCnt;
+                ++packedLane;
+                ++packedReadCount;
+            }
+        }
+        if (unlikely(packedReadCount >= totalValueNum)) {
+            fileCompleted = true;
+        }
+    }
+
+    void fillValueBufferPackedGeneric() {
+        while (valueCnt < valueBufferSize && packedReadCount < totalValueNum) {
+            if (unlikely(packedLane >= packedValuesPerWord)) {
+                if (unlikely(!loadPackedWord())) {
+                    break;
+                }
+            }
+            while (valueCnt < valueBufferSize &&
+                   packedLane < packedValuesPerWord &&
+                   packedReadCount < totalValueNum) {
+                valueBuffer[valueCnt].tInfo.taxId =
+                    static_cast<TaxID>((packedCurrentWord >> (packedLane * packedIdBits)) & packedIdMask);
+                valueBuffer[valueCnt].value = getNextMetamer();
+                ++valueCnt;
+                ++packedLane;
+                ++packedReadCount;
+            }
+        }
+        if (unlikely(packedReadCount >= totalValueNum)) {
+            fileCompleted = true;
+        }
+    }
+
+    inline bool loadPackedWord() {
+        if (unlikely(packedInfoBuffer->p >= packedInfoBuffer->end)) {
+            if (packedInfoBuffer->loadBuffer() == 0) {
+                fileCompleted = true;
+                return false;
+            }
+        }
+        packedCurrentWord = *packedInfoBuffer->p++;
+        packedLane = 0;
+        return true;
+    }
+
+    void loadPackedInfoAt(size_t logicalOffset) {
+        packedReadCount = logicalOffset;
+        const size_t wordOffset = logicalOffset / packedValuesPerWord;
+        const uint8_t targetLane = logicalOffset % packedValuesPerWord;
+        packedInfoBuffer->loadBufferAt(wordOffset);
+
+        // Starting exactly on a word boundary lets the normal refill path load
+        // the word. Starting inside a word needs that word cached immediately.
+        packedCurrentWord = 0;
+        packedLane = packedValuesPerWord;
+        if (targetLane != 0) {
+            loadPackedWord();
+            packedLane = targetLane;
+        }
+    }
+
+    inline bool readNextPackedIdGeneric(uint32_t &taxId) {
+        if (unlikely(packedReadCount >= totalValueNum)) {
+            return false;
+        }
+        if (unlikely(packedLane >= packedValuesPerWord && !loadPackedWord())) {
+            return false;
+        }
+        taxId = static_cast<uint32_t>((packedCurrentWord >> (packedLane * packedIdBits)) & packedIdMask);
+        ++packedLane;
+        ++packedReadCount;
+        return true;
+    }
+
+    template <uint8_t ID_BITS>
+    inline bool readNextPackedId(uint32_t &taxId) {
+        static constexpr uint8_t VALUES_PER_WORD = InfoIndex::WORD_BITS / ID_BITS;
+        static constexpr uint64_t ID_MASK = (uint64_t{1} << ID_BITS) - 1;
+        if (unlikely(packedReadCount >= totalValueNum)) {
+            return false;
+        }
+        if (unlikely(packedLane >= VALUES_PER_WORD && !loadPackedWord())) {
+            return false;
+        }
+        taxId = static_cast<uint32_t>((packedCurrentWord >> (packedLane * ID_BITS)) & ID_MASK);
+        ++packedLane;
+        ++packedReadCount;
+        return true;
+    }
+
+    bool readNextPackedId(uint32_t &taxId) {
+        // This is used only after a split seek to seed valueBuffer[0]. Bulk
+        // streaming uses fillValueBufferPacked() above.
+        switch (packedIdBits) {
+            case 8:  return readNextPackedId<8>(taxId);
+            case 10: return readNextPackedId<10>(taxId);
+            case 12: return readNextPackedId<12>(taxId);
+            case 16: return readNextPackedId<16>(taxId);
+            case 21: return readNextPackedId<21>(taxId);
+            default: return readNextPackedIdGeneric(taxId);
         }
     }
 
@@ -189,12 +341,28 @@ public:
         valueBufferSize(valueBufferSize), 
         readBufferSize(readBufferSize),
         deltaIdxBuffer(deltaIdxFileName, readBufferSize),
-        infoReader(infoFileName, readBufferSize)
+        infoMetadata(InfoIndex::loadMetadata(infoFileName))
     {
         lastValue = 0;
         valueCnt = 0;
         valueBuffer = new Kmer[valueBufferSize];
-        totalValueNum = infoReader.getTotalValueNum();
+        infoIsPacked = infoMetadata.isPacked();
+        if (infoIsPacked) {
+            packedIdBits = infoMetadata.idBits;
+            packedValuesPerWord = InfoIndex::idsPerWord(packedIdBits);
+            packedIdMask = InfoIndex::maskForBits(packedIdBits);
+            // readBufferSize is historically a count of 32-bit IDs. A half-size
+            // uint64 buffer keeps roughly the same byte budget for packed data.
+            const size_t wordBufferSize = std::max<size_t>(1, readBufferSize / 2);
+            packedInfoBuffer = std::make_unique<ReadBuffer<uint64_t>>(infoFileName,
+                                                                      wordBufferSize);
+            packedLane = packedValuesPerWord;
+            totalValueNum = infoMetadata.idCount;
+        } else {
+            plainInfoBuffer = std::make_unique<ReadBuffer<TaxID>>(infoFileName,
+                                                                  readBufferSize);
+            totalValueNum = FileUtil::getFileSize(infoFileName) / sizeof(TaxID);
+        }
         fillValueBuffer();
     }
 
@@ -259,19 +427,32 @@ public:
     }
 
     void setReadPosition(DiffIdxSplit offset) {
+        // The same reader instance can be reused for multiple query splits.
+        // Seeking must clear EOF state from any previous scan.
+        fileCompleted = false;
+        valueBufferCompleted = false;
         deltaIdxBuffer.loadBufferAt(offset.diffIdxOffset);
-        // infoIdxOffset is still a logical ID count. Packed readers translate
-        // it to a physical word/lane internally.
-        infoReader.loadAt(offset.infoIdxOffset - (offset.ADkmer != 0));
+        const size_t infoOffset = offset.infoIdxOffset - (offset.ADkmer != 0);
+        if (infoIsPacked) {
+            // Split offsets are logical ID counts. Packed files translate that
+            // once at seek time, then stream IDs from the chosen word/lane.
+            loadPackedInfoAt(infoOffset);
+        } else {
+            plainInfoBuffer->loadBufferAt(infoOffset);
+        }
         if (offset.ADkmer == 0 && offset.diffIdxOffset == 0 && offset.infoIdxOffset == 0) {
             valueCnt = 0;
             lastValue = 0;
         } else {
             lastValue = offset.ADkmer;
             valueBuffer[0].value = lastValue;
-            uint32_t taxId = 0;
-            infoReader.next(taxId);
-            valueBuffer[0].tInfo.taxId = taxId;
+            if (infoIsPacked) {
+                uint32_t taxId = 0;
+                readNextPackedId(taxId);
+                valueBuffer[0].tInfo.taxId = static_cast<TaxID>(taxId);
+            } else {
+                valueBuffer[0].tInfo.taxId = *plainInfoBuffer->p++;
+            }
             valueCnt = 1;
         }
         valueBufferIdx = 0;

--- a/src/commons/DeltaIdxReader.h
+++ b/src/commons/DeltaIdxReader.h
@@ -12,6 +12,7 @@
 
 #include "Kmer.h"
 #include "common.h"
+#include "InfoIndex.h"
 
 #define MEM_SIZE_16MB ((size_t) (16 * 1024 * 1024))
 #define MEM_SIZE_32MB ((size_t) (32 * 1024 * 1024))
@@ -139,26 +140,23 @@ private:
     // To manage delta indices    
     size_t readBufferSize;
     ReadBuffer<uint16_t> deltaIdxBuffer;
-    ReadBuffer<TaxID> infoBuffer;
+    // Reads either the legacy uint32 info stream or the packed final info file.
+    // The interface exposes logical IDs, so split offsets do not change.
+    InfoIndexReader infoReader;
     bool fileCompleted = false;
     bool valueBufferCompleted = false;
 
     void fillValueBuffer() {
         for (; valueCnt < valueBufferSize; ++valueCnt) {
-            if (unlikely(infoBuffer.p == infoBuffer.end)) {
-                size_t readCnt = infoBuffer.loadBuffer();
-                if (readCnt == 0) {
-                    fileCompleted = true;
-                    break;
-                }
-            }
-            valueBuffer[valueCnt].tInfo.taxId = *infoBuffer.p++;
-            valueBuffer[valueCnt].value = getNextMetamer();
-        }
-        if (infoBuffer.p == infoBuffer.end) {
-            if (infoBuffer.loadBuffer() == 0) {
+            uint32_t taxId = 0;
+            if (unlikely(!infoReader.next(taxId))) {
                 fileCompleted = true;
+                break;
             }
+            // ID retrieval is hidden behind InfoIndexReader; packed databases
+            // pay only one shift/mask per ID before the Kmer enters this buffer.
+            valueBuffer[valueCnt].tInfo.taxId = taxId;
+            valueBuffer[valueCnt].value = getNextMetamer();
         }
     }
 
@@ -191,14 +189,13 @@ public:
         valueBufferSize(valueBufferSize), 
         readBufferSize(readBufferSize),
         deltaIdxBuffer(deltaIdxFileName, readBufferSize),
-        infoBuffer(infoFileName, readBufferSize)
+        infoReader(infoFileName, readBufferSize)
     {
         lastValue = 0;
         valueCnt = 0;
         valueBuffer = new Kmer[valueBufferSize];
+        totalValueNum = infoReader.getTotalValueNum();
         fillValueBuffer();
-        // Get the size of infoFile
-        totalValueNum = FileUtil::getFileSize(infoFileName) / sizeof(TaxID);
     }
 
     ~DeltaIdxReader() {
@@ -263,14 +260,18 @@ public:
 
     void setReadPosition(DiffIdxSplit offset) {
         deltaIdxBuffer.loadBufferAt(offset.diffIdxOffset);
-        infoBuffer.loadBufferAt(offset.infoIdxOffset - (offset.ADkmer != 0));
+        // infoIdxOffset is still a logical ID count. Packed readers translate
+        // it to a physical word/lane internally.
+        infoReader.loadAt(offset.infoIdxOffset - (offset.ADkmer != 0));
         if (offset.ADkmer == 0 && offset.diffIdxOffset == 0 && offset.infoIdxOffset == 0) {
             valueCnt = 0;
             lastValue = 0;
         } else {
             lastValue = offset.ADkmer;
             valueBuffer[0].value = lastValue;
-            valueBuffer[0].tInfo.taxId = *infoBuffer.p++;
+            uint32_t taxId = 0;
+            infoReader.next(taxId);
+            valueBuffer[0].tInfo.taxId = taxId;
             valueCnt = 1;
         }
         valueBufferIdx = 0;

--- a/src/commons/IndexCreator.cpp
+++ b/src/commons/IndexCreator.cpp
@@ -898,12 +898,18 @@ void IndexCreator::writeTargetFilesAndSplits(
     uint64_t lastKmer = 0;
     WriteBuffer<uint16_t> diffBuffer(dbDir + "/diffIdx", bufferSize);
     
+    // Single-flush output is first written in the legacy uint32 layout, then
+    // converted in place once the max ID and logical count are known.
     WriteBuffer<uint32_t> infoBuffer(dbDir + "/info", bufferSize); 
+    uint32_t maxInfoId = 0;
     for (size_t i = 0; i < uniqKmerIdxRanges.size(); i ++) {
         for (size_t j = uniqKmerIdxRanges[i].first; j < uniqKmerIdxRanges[i].second; j ++) {
-            infoBuffer.write(&kmerBuffer.buffer[uniqKmerIdx[j]].id);
+            uint32_t infoId = kmerBuffer.buffer[uniqKmerIdx[j]].id;
+            maxInfoId = std::max(maxInfoId, infoId);
+            infoBuffer.write(&infoId);
             getDiffIdx(lastKmer, kmerBuffer.buffer[uniqKmerIdx[j]].value, diffBuffer);
-            // Write split info
+            // Split files use logical ID offsets, so old and packed info files
+            // share the same random-access contract.
             if (AminoAcidPart(lastKmer) != AAofTempSplitOffset && splitCheck == 1) {
                 splitList[splitListIdx++] = {lastKmer, diffBuffer.writeCnt, infoBuffer.writeCnt};
                 splitCheck = 0;
@@ -925,6 +931,11 @@ void IndexCreator::writeTargetFilesAndSplits(
     fwrite(splitList, sizeof(DiffIdxSplit), par.splitNum, deltaIdxSplitFile);
     delete[] splitList;
     fclose(deltaIdxSplitFile);
+
+    const size_t finalInfoCount = infoBuffer.writeCnt;
+    infoBuffer.close();
+    // The converter replaces dbDir/info with packed storage when it is smaller.
+    finalizeInfoIndex(dbDir + "/info", maxInfoId, finalInfoCount);
     
     kmerBuffer.startIndexOfReserve = 0; // Reset the buffer for the next batch
 }
@@ -1333,6 +1344,26 @@ size_t IndexCreator::fillTargetKmerBuffer(Buffer<Kmer> &kmerBuffer,
 }
 
 
+void IndexCreator::writeInfoMetadata() {
+    if (finalInfoMetadata.idCount == 0) {
+        return;
+    }
+    InfoIndex::appendMetadata(paramterFileName, finalInfoMetadata);
+}
+
+void IndexCreator::finalizeInfoIndex(const std::string &infoFileName,
+                                     uint32_t maxInfoId,
+                                     size_t idCount) {
+    // The final bit width is derived from the IDs that survived filtering/LCA,
+    // not from taxonomy size estimates.
+    finalInfoMetadata = InfoIndex::makeMetadata(maxInfoId, idCount);
+    packInfoFileInPlace(infoFileName, finalInfoMetadata);
+    writeInfoMetadata();
+    cout << "Info index format    : " << finalInfoMetadata.format
+         << " (" << static_cast<int>(finalInfoMetadata.idBits)
+         << " bits, " << finalInfoMetadata.idCount << " IDs)" << endl;
+}
+
 void IndexCreator::writeDbParameters() {
     FILE *handle = fopen(paramterFileName.c_str(), "w");
     if (handle == NULL) {
@@ -1353,6 +1384,11 @@ void IndexCreator::writeDbParameters() {
     }
     fprintf(handle, "Kmer_format\t%d\n", kmerFormat);
     fprintf(handle, "Total_seq_length\t%lu\n", totalLength);
+    if (finalInfoMetadata.idCount > 0) {
+        fprintf(handle, "Info_format\t%s\n", finalInfoMetadata.format.c_str());
+        fprintf(handle, "Info_id_bits\t%u\n", static_cast<unsigned int>(finalInfoMetadata.idBits));
+        fprintf(handle, "Info_id_count\t%lu\n", static_cast<unsigned long>(finalInfoMetadata.idCount));
+    }
 
     if (!par.customMetamer.empty()) {
         // Read the custom metamer file and write to parameter file

--- a/src/commons/IndexCreator.cpp
+++ b/src/commons/IndexCreator.cpp
@@ -898,8 +898,8 @@ void IndexCreator::writeTargetFilesAndSplits(
     uint64_t lastKmer = 0;
     WriteBuffer<uint16_t> diffBuffer(dbDir + "/diffIdx", bufferSize);
     
-    // Single-flush output is first written in the legacy uint32 layout, then
-    // converted in place once the max ID and logical count are known.
+    // Single-flush output is first written in the legacy uint32 layout. The
+    // finalization step may compact it once max ID and logical count are known.
     WriteBuffer<uint32_t> infoBuffer(dbDir + "/info", bufferSize); 
     uint32_t maxInfoId = 0;
     for (size_t i = 0; i < uniqKmerIdxRanges.size(); i ++) {
@@ -934,7 +934,7 @@ void IndexCreator::writeTargetFilesAndSplits(
 
     const size_t finalInfoCount = infoBuffer.writeCnt;
     infoBuffer.close();
-    // The converter replaces dbDir/info with packed storage when it is smaller.
+    // Finalization replaces dbDir/info with packed storage unless disabled.
     finalizeInfoIndex(dbDir + "/info", maxInfoId, finalInfoCount);
     
     kmerBuffer.startIndexOfReserve = 0; // Reset the buffer for the next batch
@@ -1354,6 +1354,19 @@ void IndexCreator::writeInfoMetadata() {
 void IndexCreator::finalizeInfoIndex(const std::string &infoFileName,
                                      uint32_t maxInfoId,
                                      size_t idCount) {
+    if (par.packInfo == 0) {
+        // Keep the legacy uint32 file exactly as written. This is useful for
+        // byte-for-byte compatibility tests and for users who want old DB layout.
+        finalInfoMetadata.format = "uint32";
+        finalInfoMetadata.idBits = 32;
+        finalInfoMetadata.idCount = idCount;
+        writeInfoMetadata();
+        cout << "Info index format    : " << finalInfoMetadata.format
+             << " (" << static_cast<int>(finalInfoMetadata.idBits)
+             << " bits, " << finalInfoMetadata.idCount << " IDs)" << endl;
+        return;
+    }
+
     // The final bit width is derived from the IDs that survived filtering/LCA,
     // not from taxonomy size estimates.
     finalInfoMetadata = InfoIndex::makeMetadata(maxInfoId, idCount);

--- a/src/commons/IndexCreator.h
+++ b/src/commons/IndexCreator.h
@@ -33,6 +33,7 @@
 #include "GeneticCode.h"
 #include "KmerExtractor.h"
 #include "DeltaIdxReader.h"
+#include "InfoIndex.h"
 #include "UnirefTree.h"
 #include "MetamerPattern.h"
 
@@ -149,6 +150,7 @@ protected:
     std::string mergedDeltaIdxFileName;
     std::string mergedInfoFileName;
     std::string deltaIdxSplitFileName;
+    InfoIndexMetadata finalInfoMetadata;
     struct Split{
         Split(size_t offset, size_t end) : offset(offset), end(end) {}
         size_t offset;
@@ -171,6 +173,8 @@ protected:
         const vector<pair<size_t, size_t>> & uniqKmerIdxRanges);
 
     void writeDbParameters();
+    void writeInfoMetadata();
+    void finalizeInfoIndex(const std::string &infoFileName, uint32_t maxInfoId, size_t idCount);
 
     size_t fillTargetKmerBuffer(
         Buffer<Kmer> &kmerBuffer,                 
@@ -328,6 +332,8 @@ template <FilterMode M>
 void IndexCreator::mergeTargetFiles() {
     size_t bufferSize = 1024 * 1024 * 512;
     WriteBuffer<uint16_t> diffBuffer(mergedDeltaIdxFileName, bufferSize);
+    // Merge output is written as uint32 first. After the stream is complete,
+    // finalizeInfoIndex() packs it using the actual max ID and logical count.
     WriteBuffer<uint32_t> infoBuffer(mergedInfoFileName, bufferSize);
     
     // Prepare files to merge
@@ -371,6 +377,9 @@ void IndexCreator::mergeTargetFiles() {
     int remainingSplits = splitNum;
     vector<pair<size_t, size_t>> uniqKmerIdxRanges;
     uint64_t lastKmer = 0;
+    // Track the selected IDs that actually reach disk. This determines the
+    // smallest useful bit width for the final packed info file.
+    uint32_t maxInfoId = 0;
     auto * uniqKmerIdx = new size_t[kmerBuffer.bufferSize];
     vector<size_t> splitToProcess;
     while (remainingSplits > 0) {
@@ -436,10 +445,13 @@ void IndexCreator::mergeTargetFiles() {
         // Write       
         for (size_t i = 0; i < uniqKmerIdxRanges.size(); i ++) {
             for (size_t j = uniqKmerIdxRanges[i].first; j < uniqKmerIdxRanges[i].second; j ++) {
-                infoBuffer.write(&kmerBuffer.buffer[uniqKmerIdx[j]].id);
+                uint32_t infoId = kmerBuffer.buffer[uniqKmerIdx[j]].id;
+                maxInfoId = std::max(maxInfoId, infoId);
+                infoBuffer.write(&infoId);
                 getDiffIdx(lastKmer, kmerBuffer.buffer[uniqKmerIdx[j]].value, diffBuffer);
 
-                // Write split info
+                // Split offsets stay in logical ID units, independent of the
+                // final physical info encoding.
                 if (AminoAcidPart(lastKmer) != AAofTempSplitOffset && splitCheck == 1) {
                     splitList[splitListIdx++] = {lastKmer, diffBuffer.writeCnt, infoBuffer.writeCnt};
                     splitCheck = 0;
@@ -463,11 +475,16 @@ void IndexCreator::mergeTargetFiles() {
     FILE * diffIdxSplitFile = fopen(deltaIdxSplitFileName.c_str(), "wb");
     fwrite(splitList, sizeof(DiffIdxSplit), par.splitNum, diffIdxSplitFile);
     fclose(diffIdxSplitFile);
+    const size_t finalInfoCount = infoBuffer.writeCnt;
+    infoBuffer.close();
+    // Packing happens only after close so the converter can stream the complete
+    // uint32 file into a compact replacement.
+    finalizeInfoIndex(mergedInfoFileName, maxInfoId, finalInfoCount);
     // for(int i = 0; i < par.splitNum; i++) {
     //     cout<<splitList[i].ADkmer<< " "<<splitList[i].diffIdxOffset<< " "<<splitList[i].infoIdxOffset<<endl;
     // }
     cout<<"DB creation completed"<<endl;
-    cout<<"Total k-mer count   : " << infoBuffer.writeCnt <<endl;
+    cout<<"Total k-mer count   : " << finalInfoCount <<endl;
 
     cout<<"DB files you need   : " << endl;
     cout<<mergedDeltaIdxFileName<<endl;

--- a/src/commons/IndexCreator.h
+++ b/src/commons/IndexCreator.h
@@ -333,7 +333,7 @@ void IndexCreator::mergeTargetFiles() {
     size_t bufferSize = 1024 * 1024 * 512;
     WriteBuffer<uint16_t> diffBuffer(mergedDeltaIdxFileName, bufferSize);
     // Merge output is written as uint32 first. After the stream is complete,
-    // finalizeInfoIndex() packs it using the actual max ID and logical count.
+    // finalizeInfoIndex() either packs it or records the raw uint32 metadata.
     WriteBuffer<uint32_t> infoBuffer(mergedInfoFileName, bufferSize);
     
     // Prepare files to merge
@@ -377,8 +377,8 @@ void IndexCreator::mergeTargetFiles() {
     int remainingSplits = splitNum;
     vector<pair<size_t, size_t>> uniqKmerIdxRanges;
     uint64_t lastKmer = 0;
-    // Track the selected IDs that actually reach disk. This determines the
-    // smallest useful bit width for the final packed info file.
+    // Track the selected IDs that actually reach disk. If packing is enabled,
+    // this determines the smallest useful bit width for the final info file.
     uint32_t maxInfoId = 0;
     auto * uniqKmerIdx = new size_t[kmerBuffer.bufferSize];
     vector<size_t> splitToProcess;
@@ -477,8 +477,8 @@ void IndexCreator::mergeTargetFiles() {
     fclose(diffIdxSplitFile);
     const size_t finalInfoCount = infoBuffer.writeCnt;
     infoBuffer.close();
-    // Packing happens only after close so the converter can stream the complete
-    // uint32 file into a compact replacement.
+    // Finalization happens only after close so optional packing can stream the
+    // complete uint32 file into a compact replacement.
     finalizeInfoIndex(mergedInfoFileName, maxInfoId, finalInfoCount);
     // for(int i = 0; i < par.splitNum; i++) {
     //     cout<<splitList[i].ADkmer<< " "<<splitList[i].diffIdxOffset<< " "<<splitList[i].infoIdxOffset<<endl;

--- a/src/commons/InfoIndex.h
+++ b/src/commons/InfoIndex.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "common.h"
 
@@ -127,10 +128,58 @@ struct InfoIndex {
                       << " for writing info index metadata\n";
             std::exit(EXIT_FAILURE);
         }
+        writeMetadata(handle, meta);
+        fclose(handle);
+    }
+
+    static void upsertMetadata(const std::string &parameterFileName,
+                               const InfoIndexMetadata &meta) {
+        std::vector<std::string> keptLines;
+        {
+            std::ifstream in(parameterFileName);
+            std::string line;
+            while (std::getline(in, line)) {
+                const size_t tab = line.find('\t');
+                const std::string key = (tab == std::string::npos) ? line : line.substr(0, tab);
+                // Maintenance commands may run more than once. Drop all old info
+                // metadata keys and write one authoritative block at the end.
+                if (!isMetadataKey(key)) {
+                    keptLines.push_back(line);
+                }
+            }
+        }
+
+        const std::string tmpFileName = parameterFileName + ".info.tmp";
+        FILE *handle = fopen(tmpFileName.c_str(), "w");
+        if (handle == nullptr) {
+            std::cerr << "Could not open " << tmpFileName
+                      << " for writing info index metadata\n";
+            std::exit(EXIT_FAILURE);
+        }
+        for (const std::string &line : keptLines) {
+            fprintf(handle, "%s\n", line.c_str());
+        }
+        writeMetadata(handle, meta);
+        fclose(handle);
+
+        if (std::rename(tmpFileName.c_str(), parameterFileName.c_str()) != 0) {
+            std::cerr << "Could not replace " << parameterFileName
+                      << " with updated info index metadata\n";
+            std::exit(EXIT_FAILURE);
+        }
+    }
+
+private:
+    static bool isMetadataKey(const std::string &key) {
+        return key == "Info_format" ||
+               key == "Info_id_bits" ||
+               key == "Info_id_count";
+    }
+
+    static void writeMetadata(FILE *handle, const InfoIndexMetadata &meta) {
         fprintf(handle, "Info_format\t%s\n", meta.format.c_str());
         fprintf(handle, "Info_id_bits\t%u\n", static_cast<unsigned int>(meta.idBits));
         fprintf(handle, "Info_id_count\t%lu\n", static_cast<unsigned long>(meta.idCount));
-        fclose(handle);
     }
 };
 

--- a/src/commons/InfoIndex.h
+++ b/src/commons/InfoIndex.h
@@ -1,0 +1,342 @@
+#ifndef METABULI_INFOINDEX_H
+#define METABULI_INFOINDEX_H
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "common.h"
+
+// Metadata stored in db.parameters for the final "info" file. Older databases
+// do not have these keys; absence means the file is the original uint32 stream.
+struct InfoIndexMetadata {
+    std::string format = "uint32"; // "uint32" or "packed_uint"
+    uint8_t idBits = 32;           // Bits used by each logical ID.
+    size_t idCount = 0;            // Logical ID count, excluding padded lanes.
+
+    bool isPacked() const {
+        return format == "packed_uint" && idBits < 32;
+    }
+};
+
+struct InfoIndex {
+    static constexpr uint8_t WORD_BITS = 64;
+
+    // Metadata lives next to the final info file in db.parameters.
+    static std::string dbParameterFile(const std::string &infoFileName) {
+        const size_t slash = infoFileName.find_last_of('/');
+        if (slash == std::string::npos) {
+            return "db.parameters";
+        }
+        return infoFileName.substr(0, slash + 1) + "db.parameters";
+    }
+
+    // Temporary merge chunks are named "<n>_info" and remain raw uint32. Only
+    // the final database file is named exactly "info" and can use metadata.
+    static bool isFinalInfoFile(const std::string &infoFileName) {
+        const size_t slash = infoFileName.find_last_of('/');
+        const std::string base = (slash == std::string::npos)
+                                     ? infoFileName
+                                     : infoFileName.substr(slash + 1);
+        return base == "info";
+    }
+
+    static uint8_t idsPerWord(uint8_t idBits) {
+        return std::max<uint8_t>(1, WORD_BITS / idBits);
+    }
+
+    static uint64_t maskForBits(uint8_t idBits) {
+        return idBits == 64 ? UINT64_MAX : ((uint64_t{1} << idBits) - 1);
+    }
+
+    static size_t packedWordCount(size_t idCount, uint8_t idBits) {
+        const size_t perWord = idsPerWord(idBits);
+        return (idCount + perWord - 1) / perWord;
+    }
+
+    static uint8_t chooseIdBits(uint32_t maxId) {
+        // Tiers are chosen only where they improve IDs-per-word density. For
+        // example, 18 and 21 bits both fit three IDs per uint64, so 21 keeps
+        // more future headroom at the same file size.
+        static constexpr uint8_t TIERS[] = {8, 10, 12, 16, 21, 32};
+        for (uint8_t bits : TIERS) {
+            if (bits == 32 || maxId <= maskForBits(bits)) {
+                return bits;
+            }
+        }
+        return 32;
+    }
+
+    static InfoIndexMetadata makeMetadata(uint32_t maxId, size_t idCount) {
+        InfoIndexMetadata meta;
+        meta.idBits = chooseIdBits(maxId);
+        meta.idCount = idCount;
+        meta.format = (meta.idBits < 32) ? "packed_uint" : "uint32";
+        return meta;
+    }
+
+    static InfoIndexMetadata loadMetadata(const std::string &infoFileName) {
+        InfoIndexMetadata meta;
+        // Non-final info files are intermediate merge inputs. They must stay
+        // readable without a db.parameters side channel.
+        if (!isFinalInfoFile(infoFileName)) {
+            return meta;
+        }
+
+        std::ifstream in(dbParameterFile(infoFileName));
+        if (!in.is_open()) {
+            return meta;
+        }
+
+        std::string line;
+        while (std::getline(in, line)) {
+            const size_t tab = line.find('\t');
+            if (tab == std::string::npos) {
+                continue;
+            }
+            const std::string key = line.substr(0, tab);
+            const std::string value = line.substr(tab + 1);
+            if (key == "Info_format") {
+                meta.format = value;
+            } else if (key == "Info_id_bits") {
+                meta.idBits = static_cast<uint8_t>(std::stoul(value));
+            } else if (key == "Info_id_count") {
+                meta.idCount = static_cast<size_t>(std::stoull(value));
+            }
+        }
+
+        // Be conservative with incomplete or unknown metadata. Falling back to
+        // uint32 preserves compatibility with old databases and temp chunks.
+        if (meta.format != "packed_uint" || meta.idBits >= 32 || meta.idCount == 0) {
+            meta.format = "uint32";
+            meta.idBits = 32;
+        }
+        return meta;
+    }
+
+    static void appendMetadata(const std::string &parameterFileName,
+                               const InfoIndexMetadata &meta) {
+        FILE *handle = fopen(parameterFileName.c_str(), "a");
+        if (handle == nullptr) {
+            std::cerr << "Could not open " << parameterFileName
+                      << " for writing info index metadata\n";
+            std::exit(EXIT_FAILURE);
+        }
+        fprintf(handle, "Info_format\t%s\n", meta.format.c_str());
+        fprintf(handle, "Info_id_bits\t%u\n", static_cast<unsigned int>(meta.idBits));
+        fprintf(handle, "Info_id_count\t%lu\n", static_cast<unsigned long>(meta.idCount));
+        fclose(handle);
+    }
+};
+
+class InfoIndexWriter {
+private:
+    const uint8_t idBits;
+    const uint8_t valuesPerWord;
+    const uint64_t idMask;
+    WriteBuffer<uint64_t> wordBuffer;
+    uint64_t currentWord = 0; // Accumulates IDs until one uint64 word is full.
+    uint8_t lane = 0;         // Logical slot inside currentWord.
+    bool closed = false;
+
+public:
+    InfoIndexWriter(const std::string &fileName,
+                    uint8_t idBits,
+                    size_t wordBufferSize)
+        : idBits(idBits),
+          valuesPerWord(InfoIndex::idsPerWord(idBits)),
+          idMask(InfoIndex::maskForBits(idBits)),
+          wordBuffer(fileName, wordBufferSize) {}
+
+    ~InfoIndexWriter() {
+        close();
+    }
+
+    inline void write(uint32_t id) {
+        // Validate once on write so the reader can stay branch-light.
+        if (unlikely((static_cast<uint64_t>(id) & ~idMask) != 0)) {
+            std::cerr << "Info ID " << id << " exceeds " << static_cast<int>(idBits)
+                      << " packed bits\n";
+            std::exit(EXIT_FAILURE);
+        }
+
+        // Hot packing path: one masked shift/or per logical ID, then flush a
+        // complete 64-bit word when the current lane group is full.
+        currentWord |= (static_cast<uint64_t>(id) << (lane * idBits));
+        ++lane;
+        if (unlikely(lane == valuesPerWord)) {
+            wordBuffer.write(&currentWord);
+            currentWord = 0;
+            lane = 0;
+        }
+    }
+
+    void close() {
+        if (closed) {
+            return;
+        }
+        // The last word may contain unused lanes; Info_id_count tells readers
+        // where the logical stream ends.
+        if (lane != 0) {
+            wordBuffer.write(&currentWord);
+            currentWord = 0;
+            lane = 0;
+        }
+        wordBuffer.close();
+        closed = true;
+    }
+};
+
+class InfoIndexReader {
+private:
+    InfoIndexMetadata metadata;
+    // Exactly one buffer is active. Keeping separate typed buffers avoids
+    // per-ID virtual dispatch or conversions in DeltaIdxReader's hot loop.
+    std::unique_ptr<ReadBuffer<uint32_t>> plainBuffer;
+    std::unique_ptr<ReadBuffer<uint64_t>> packedBuffer;
+    uint8_t valuesPerWord = 2;
+    uint64_t idMask = UINT32_MAX;
+    uint64_t currentWord = 0; // Current packed word being decoded.
+    uint8_t lane = 0;         // Next logical ID slot inside currentWord.
+    size_t readCount = 0;     // Logical IDs returned so far from this reader.
+    size_t totalValueNum = 0;
+
+    inline bool loadPackedWord() {
+        // ReadBuffer batches disk IO; this only advances to the next uint64
+        // word when all packed lanes from the current word have been consumed.
+        if (unlikely(packedBuffer->p >= packedBuffer->end)) {
+            if (packedBuffer->loadBuffer() == 0) {
+                return false;
+            }
+        }
+        currentWord = *packedBuffer->p++;
+        lane = 0;
+        return true;
+    }
+
+public:
+    InfoIndexReader(const std::string &infoFileName, size_t readBufferSize)
+        : metadata(InfoIndex::loadMetadata(infoFileName)) {
+        if (metadata.isPacked()) {
+            valuesPerWord = InfoIndex::idsPerWord(metadata.idBits);
+            idMask = InfoIndex::maskForBits(metadata.idBits);
+            // readBufferSize is historically a uint32 count. Halving keeps the
+            // packed uint64 byte budget close to the old reader budget.
+            const size_t wordBufferSize = std::max<size_t>(1, readBufferSize / 2);
+            packedBuffer = std::make_unique<ReadBuffer<uint64_t>>(infoFileName,
+                                                                  wordBufferSize);
+            lane = valuesPerWord;
+            totalValueNum = metadata.idCount;
+        } else {
+            plainBuffer = std::make_unique<ReadBuffer<uint32_t>>(infoFileName,
+                                                                 readBufferSize);
+            totalValueNum = FileUtil::getFileSize(infoFileName) / sizeof(uint32_t);
+        }
+    }
+
+    bool isPacked() const {
+        return metadata.isPacked();
+    }
+
+    size_t getTotalValueNum() const {
+        return totalValueNum;
+    }
+
+    bool loadAt(size_t logicalOffset) {
+        readCount = logicalOffset;
+        if (!metadata.isPacked()) {
+            return plainBuffer->loadBufferAt(logicalOffset) > 0 || logicalOffset == totalValueNum;
+        }
+
+        // Split files store logical ID offsets, not physical byte/word offsets.
+        // Convert once during seek; next() then only shifts and masks.
+        const size_t wordOffset = logicalOffset / valuesPerWord;
+        const uint8_t targetLane = logicalOffset % valuesPerWord;
+        if (packedBuffer->loadBufferAt(wordOffset) == 0 && logicalOffset != totalValueNum) {
+            return false;
+        }
+
+        lane = valuesPerWord;
+        currentWord = 0;
+        if (targetLane != 0) {
+            if (!loadPackedWord()) {
+                return false;
+            }
+            lane = targetLane;
+        }
+        return true;
+    }
+
+    inline bool next(uint32_t &id) {
+        if (!metadata.isPacked()) {
+            if (unlikely(plainBuffer->p >= plainBuffer->end)) {
+                if (plainBuffer->loadBuffer() == 0) {
+                    return false;
+                }
+            }
+            id = *plainBuffer->p++;
+            ++readCount;
+            return true;
+        }
+
+        if (unlikely(readCount >= totalValueNum)) {
+            return false;
+        }
+        if (unlikely(lane >= valuesPerWord && !loadPackedWord())) {
+            return false;
+        }
+
+        // Hot unpacking path: the split seek has already selected the word and
+        // lane, so retrieval is one shift, one mask, and one lane increment.
+        id = static_cast<uint32_t>((currentWord >> (lane * metadata.idBits)) & idMask);
+        ++lane;
+        ++readCount;
+        return true;
+    }
+};
+
+inline void packInfoFileInPlace(const std::string &infoFileName,
+                                const InfoIndexMetadata &metadata) {
+    if (!metadata.isPacked()) {
+        return;
+    }
+
+    // Final writers first produce the old uint32 stream. Packing afterwards
+    // lets merge code compute max ID/count in one pass without buffering all IDs.
+    const std::string packedFileName = infoFileName + ".packed.tmp";
+    {
+        ReadBuffer<uint32_t> reader(infoFileName, 1024 * 1024 * 16);
+        InfoIndexWriter writer(packedFileName, metadata.idBits, 1024 * 1024 * 8);
+        uint32_t id = 0;
+        size_t written = 0;
+        while (reader.p < reader.end || reader.loadBuffer() != 0) {
+            while (reader.p < reader.end) {
+                id = *reader.p++;
+                writer.write(id);
+                ++written;
+            }
+        }
+        // This catches accidental count mismatches before replacing the final
+        // database info file.
+        if (written != metadata.idCount) {
+            std::cerr << "Info ID count changed while packing " << infoFileName
+                      << ": expected " << metadata.idCount << ", saw " << written << "\n";
+            std::exit(EXIT_FAILURE);
+        }
+        writer.close();
+    }
+
+    if (std::remove(infoFileName.c_str()) != 0 ||
+        std::rename(packedFileName.c_str(), infoFileName.c_str()) != 0) {
+        std::cerr << "Could not replace " << infoFileName
+                  << " with packed info index\n";
+        std::exit(EXIT_FAILURE);
+    }
+}
+
+#endif // METABULI_INFOINDEX_H

--- a/src/commons/LocalParameters.cpp
+++ b/src/commons/LocalParameters.cpp
@@ -403,6 +403,13 @@ LocalParameters::LocalParameters() :
                 typeid(std::string),
                 (void *) &noMaskTaxa,
                 "^.*$"),
+        PACK_INFO(PACK_INFO_ID,
+                "--pack-info",
+                "Pack final info index",
+                "Pack final info index. Set to 0 to keep the legacy uint32 info file.",
+                typeid(int),
+                (void *) &packInfo,
+                "[0-1]"),
         NEW_TAXA(NEW_TAXA_ID,
                 "--new-taxa",
                 "TSV file of new taxa to be added",
@@ -592,6 +599,7 @@ LocalParameters::LocalParameters() :
     splitNum = 0;
     bufferSize = 0;
     accessionLevel = 0;
+    packInfo = 1;
 
     // Test parameters
     testRank = "";
@@ -652,6 +660,7 @@ LocalParameters::LocalParameters() :
     build.push_back(&SPACE_MASK);
     build.push_back(&READING_FRAME);
     build.push_back(&NO_MASK_TAXA);
+    build.push_back(&PACK_INFO);
 
     createCommonKmerList.push_back(&PARAM_THREADS);
     createCommonKmerList.push_back(&PARAM_MASK_PROBABILTY);
@@ -680,6 +689,7 @@ LocalParameters::LocalParameters() :
     updateDB.push_back(&VALIDATE_DB);
     // updateDB.push_back(&SYNCMER);
     updateDB.push_back(&NO_MASK_TAXA);
+    updateDB.push_back(&PACK_INFO);
 
     //classify
     classify.push_back(&PARAM_THREADS);

--- a/src/commons/LocalParameters.h
+++ b/src/commons/LocalParameters.h
@@ -45,6 +45,7 @@ public:
     std::vector<MMseqsParameter*> createnewtaxalist;
     std::vector<MMseqsParameter*> classifiedRefiner;
     std::vector<MMseqsParameter*> validateDatabase;
+    std::vector<MMseqsParameter*> compactInfoIndex;
     std::vector<MMseqsParameter*> makeBenchmarkSet;
     std::vector<MMseqsParameter*> buildUnirefDb;
     std::vector<MMseqsParameter*> buildUnirefTree;

--- a/src/commons/LocalParameters.h
+++ b/src/commons/LocalParameters.h
@@ -126,6 +126,7 @@ public:
     PARAMETER(VALIDATE_INPUT)
     PARAMETER(READING_FRAME)
     PARAMETER(NO_MASK_TAXA)
+    PARAMETER(PACK_INFO)
 
     // DB updated parameters
     PARAMETER(NEW_TAXA)
@@ -229,6 +230,7 @@ public:
     int validateInput;
     int readingFrame;
     std::string noMaskTaxa;
+    int packInfo;
 
     // DB updated parameters
     std::string newTaxa;

--- a/src/commons/common.cpp
+++ b/src/commons/common.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "FileUtil.h"
+#include "InfoIndex.h"
 #include "TaxonomyWrapper.h"
 #include <fstream>
 #include <iostream>
@@ -357,8 +358,11 @@ size_t readDbSize(const std::string& dbDir) {
     std::cerr << "Cannot get the size of the info file" << std::endl;
     exit(1);
   }
+  // New packed DBs store the logical k-mer count in db.parameters because file
+  // size includes padded lanes in the last packed word.
+  InfoIndexMetadata infoMeta = InfoIndex::loadMetadata(path);
   size_t fileSize = sb.st_size;
-  size_t kmerCnt = fileSize / sizeof(TaxID);
+  size_t kmerCnt = infoMeta.isPacked() ? infoMeta.idCount : fileSize / sizeof(TaxID);
   size_t dnaLength = kmerCnt * 3;
 
   return dnaLength * 3;  // Multiply by 3 for more conservative estimation.

--- a/src/commons/common.h
+++ b/src/commons/common.h
@@ -296,12 +296,7 @@ struct WriteBuffer {
     };
 
     ~WriteBuffer() {
-        if (size > 0) {
-            flush();
-        }
-        if (fp) {
-            fclose(fp);
-        }
+        close();
         if (buffer) {
             free(buffer);
         }
@@ -310,6 +305,16 @@ struct WriteBuffer {
     void flush() {
         fwrite(buffer, sizeof(T), size, fp);
         size = 0;
+    }
+
+    void close() {
+        if (fp) {
+            if (size > 0) {
+                flush();
+            }
+            fclose(fp);
+            fp = nullptr;
+        }
     }
 
     void write(T *data, size_t dataNum = 1) {

--- a/src/uniref/UnirefClassifier.cpp
+++ b/src/uniref/UnirefClassifier.cpp
@@ -20,7 +20,7 @@ size_t UnirefClassifier::calculateBufferSize() {
   size_t bytesPerThread = 2 * 1024 * 1024 * sizeof(Match_AA) // Local match buffer
                         + 1024 * 1024 * sizeof(Kmer)    // DeltaIdxReader::valueBuffer
                         + 1024 * 1024 * sizeof(uint16_t)     // DeltaIdxReader::deltaIdxBuffer
-                        + 1024 * 1024 * sizeof(uint32_t);    // DeltaIdxReader::infoBuffer
+                        + 1024 * 1024 * sizeof(uint32_t);    // DeltaIdxReader::InfoIndexReader byte budget
   
   size_t overhead = 128 * 1024 * 1024;
   size_t queryListBytes = 512 * 1024 * (sizeof(ProteinQuery) + 40);

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -17,6 +17,7 @@ set(util_source_files
         util/createnewtaxalist.h
         util/classifiedRefiner.cpp
         util/validateDatabase.cpp
+        util/compactInfoIndex.cpp
         util/validateDatabase.h
         util/printDeltaIdx.cpp
         util/count_common_kmers.cpp

--- a/src/util/compactInfoIndex.cpp
+++ b/src/util/compactInfoIndex.cpp
@@ -1,0 +1,122 @@
+#include "Command.h"
+#include "FileUtil.h"
+#include "InfoIndex.h"
+#include "LocalParameters.h"
+#include "validateDatabase.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+struct PlainInfoStats {
+    uint32_t maxId = 0;
+    size_t idCount = 0;
+};
+
+PlainInfoStats scanPlainInfoFile(const std::string &infoFileName) {
+    const uint64_t fileSize = FileUtil::getFileSize(infoFileName);
+    if (fileSize == 0) {
+        std::cerr << "Error: info file is empty: " << infoFileName << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    if (fileSize % sizeof(uint32_t) != 0) {
+        std::cerr << "Error: raw info file size is not a multiple of "
+                  << sizeof(uint32_t) << ": " << infoFileName << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+
+    PlainInfoStats stats;
+    ReadBuffer<uint32_t> reader(infoFileName, 1024 * 1024 * 16);
+    while (reader.p < reader.end || reader.loadBuffer() != 0) {
+        while (reader.p < reader.end) {
+            const uint32_t id = *reader.p++;
+            stats.maxId = std::max(stats.maxId, id);
+            ++stats.idCount;
+        }
+    }
+    return stats;
+}
+
+int compactInfoIndexDatabase(const std::string &dbDir) {
+    if (!FileUtil::directoryExists(dbDir.c_str())) {
+        std::cerr << "Error: database directory does not exist: " << dbDir << std::endl;
+        return 1;
+    }
+
+    const std::string infoFileName = dbDir + "/info";
+    const std::string parameterFileName = dbDir + "/db.parameters";
+    if (!FileUtil::fileExists(infoFileName.c_str())) {
+        std::cerr << "Error: info file is missing in database directory: "
+                  << dbDir << std::endl;
+        return 1;
+    }
+
+    const uint64_t originalBytes = FileUtil::getFileSize(infoFileName);
+    const InfoIndexMetadata existingMetadata = InfoIndex::loadMetadata(infoFileName);
+    if (existingMetadata.isPacked()) {
+        const size_t expectedBytes =
+            InfoIndex::packedWordCount(existingMetadata.idCount, existingMetadata.idBits) *
+            sizeof(uint64_t);
+        // If metadata and file size disagree, guessing the current physical
+        // layout could corrupt the DB. Stop and let the user inspect it.
+        if (originalBytes != expectedBytes) {
+            std::cerr << "Error: db.parameters says info is packed, but info size is "
+                      << originalBytes << " bytes; expected " << expectedBytes
+                      << " bytes." << std::endl;
+            return 1;
+        }
+        std::cout << "Info index is already packed: "
+                  << static_cast<int>(existingMetadata.idBits) << " bits, "
+                  << existingMetadata.idCount << " IDs." << std::endl;
+        return validateDatabase(dbDir);
+    }
+
+    std::cout << "Scanning raw info index..." << std::endl;
+    const PlainInfoStats stats = scanPlainInfoFile(infoFileName);
+    InfoIndexMetadata metadata = InfoIndex::makeMetadata(stats.maxId, stats.idCount);
+    std::cout << "Info ID count       : " << metadata.idCount << std::endl;
+    std::cout << "Max info ID         : " << stats.maxId << std::endl;
+    std::cout << "Selected info format: " << metadata.format << " ("
+              << static_cast<int>(metadata.idBits) << " bits)" << std::endl;
+
+    if (!metadata.isPacked()) {
+        // IDs that need 32 bits cannot be compacted by this format. Still write
+        // metadata so future readers know the logical count explicitly.
+        InfoIndex::upsertMetadata(parameterFileName, metadata);
+        std::cout << "Info IDs require 32 bits; info file was left unchanged." << std::endl;
+        return validateDatabase(dbDir);
+    }
+
+    const size_t expectedPackedBytes =
+        InfoIndex::packedWordCount(metadata.idCount, metadata.idBits) * sizeof(uint64_t);
+    std::cout << "Original info bytes : " << originalBytes << std::endl;
+    std::cout << "Packed info bytes   : " << expectedPackedBytes << std::endl;
+
+    // packInfoFileInPlace streams the raw uint32 file, validates the logical ID
+    // count, and only then replaces DBDIR/info with the packed file.
+    packInfoFileInPlace(infoFileName, metadata);
+    InfoIndex::upsertMetadata(parameterFileName, metadata);
+
+    const uint64_t packedBytes = FileUtil::getFileSize(infoFileName);
+    if (packedBytes != expectedPackedBytes) {
+        std::cerr << "Error: packed info size is " << packedBytes
+                  << " bytes; expected " << expectedPackedBytes << " bytes." << std::endl;
+        return 1;
+    }
+
+    std::cout << "Info index compacted successfully." << std::endl;
+    std::cout << "Saved bytes         : " << (originalBytes - packedBytes) << std::endl;
+    return validateDatabase(dbDir);
+}
+
+} // namespace
+
+int compactInfoIndex(int argc, const char **argv, const Command &command) {
+    LocalParameters &par = LocalParameters::getLocalInstance();
+    par.parseParameters(argc, argv, command, true, Parameters::PARSE_ALLOW_EMPTY, 0);
+    return compactInfoIndexDatabase(par.filenames[0]);
+}

--- a/src/util/printinfo.cpp
+++ b/src/util/printinfo.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include "KmerMatcher.h"
 #include "common.h"
+#include "InfoIndex.h"
 #include "SeqIterator.h"
 
 using namespace std;
@@ -19,71 +20,21 @@ int printInfo(int argc, const char **argv, const Command &command){
     par.parseParameters(argc, argv, command, false, Parameters::PARSE_ALLOW_EMPTY, 0);
     string infoFileName = par.filenames[0];
     
-    // ReadBuffer<uint32_t> infoIdxFile(infoFileName, 1024 * 1024 * 16);
-    size_t maxIdx = FileUtil::getFileSize(infoFileName) / sizeof(uint32_t);
+    InfoIndexReader infoIdxFile(infoFileName, 1024 * 1024 * 16);
+    size_t maxIdx = infoIdxFile.getTotalValueNum();
     size_t begin = par.infoBegin;
     size_t end = par.infoEnd;
     if (end > maxIdx) {
         end = maxIdx;
     }
-
-    size_t threadCnt = par.threads;
-    vector<pair<size_t, size_t>> ranges;
-    size_t chunkSize = (end - begin) / threadCnt;
-    for (size_t i = 0; i < threadCnt; i++) {
-        size_t start = begin + i * chunkSize;
-        size_t stop = (i == threadCnt - 1) ? end : start + chunkSize;
-        if (stop > maxIdx) {
-            stop = maxIdx;
-        }
-        ranges.emplace_back(start, stop);
+    if (begin > end) {
+        begin = end;
     }
 
-    uint32_t * infoArray = new uint32_t[maxIdx];
-
-    ReadBuffer<uint32_t> infoIdxFile(infoFileName, 1024 * 1024 * 16);
-    size_t idx = 0;
-    uint32_t value;
-    while ((value = infoIdxFile.getNext()) > 0) {
-        if (begin <= idx && idx < end) {
-            std::cout << value << std::endl;
-        }
-        idx++;
+    infoIdxFile.loadAt(begin);
+    uint32_t value = 0;
+    for (size_t idx = begin; idx < end && infoIdxFile.next(value); ++idx) {
+        std::cout << value << std::endl;
     }
-
-
-    // unordered_map<uint32_t, size_t> id2Cnt;
-    vector<uint32_t> id2Cnt;
-    // id2Cnt.resize(500'000'000); // Initial size, can be adjusted based on expected number of unique IDs
-    #pragma omp parallel default(none) shared(cout, infoFileName, id2Cnt, ranges)
-    {
-        vector<uint32_t> local_id2Cnt;
-        // local_id2Cnt.resize(500'000'000);
-        ReadBuffer<uint32_t> infoIdxFile(infoFileName, 1024 * 1024 * 16);
-        // unordered_map<uint32_t, size_t> local_id2Cnt;
-        size_t threadId = omp_get_thread_num();
-        size_t begin = ranges[threadId].first;
-        size_t end = ranges[threadId].second;
-        infoIdxFile.loadBufferAt(begin);
-        for (size_t i = begin; i < end; i++) {
-            uint32_t id = infoIdxFile.getNext();
-            std::cout << id << std::endl;
-            // local_id2Cnt[id]++;
-        }
-        // #pragma omp critical
-        // {   
-        //     for (size_t i = 0; i < local_id2Cnt.size(); i++) {
-        //         id2Cnt[i] += local_id2Cnt[i];
-        //     }
-        // }
-    }
-    size_t totalCount = 0;
-    for (size_t i = 0; i < id2Cnt.size(); i++) {
-        if (id2Cnt[i] > 0) {
-            totalCount ++;
-            // cout << "ID: " << i << ", Count: " << id2Cnt[i] << endl;
-        }
-    }
-    cout << "number of unique ids: " << totalCount << endl;
     return 0;
 }

--- a/src/util/validateDatabase.cpp
+++ b/src/util/validateDatabase.cpp
@@ -1,6 +1,7 @@
 #include "LocalParameters.h"
 #include "FileUtil.h"
 #include "Debug.h"
+#include "InfoIndex.h"
 #include "Mmap.h"
 
 #include "validateDatabase.h"
@@ -115,11 +116,25 @@ int validateDatabase(const std::string & dbDir) {
             cerr << "Error: info file is empty." << endl;
             return 1;
         }
-        if (fileSize % sizeof(int) != 0) {
-            cerr << "Error: info file size is not a multiple of " << sizeof(int) << "." << endl;
-            return 1;
+        // Packed info files need metadata to distinguish real IDs from padding
+        // in the final uint64 word.
+        InfoIndexMetadata infoMeta = InfoIndex::loadMetadata(infoFileName);
+        size_t kmerIdNum = 0;
+        if (infoMeta.isPacked()) {
+            size_t expectedSize = InfoIndex::packedWordCount(infoMeta.idCount, infoMeta.idBits) * sizeof(uint64_t);
+            if (fileSize != expectedSize) {
+                cerr << "Error: packed info file size is " << fileSize
+                     << " bytes, expected " << expectedSize << " bytes." << endl;
+                return 1;
+            }
+            kmerIdNum = infoMeta.idCount;
+        } else {
+            if (fileSize % sizeof(uint32_t) != 0) {
+                cerr << "Error: info file size is not a multiple of " << sizeof(uint32_t) << "." << endl;
+                return 1;
+            }
+            kmerIdNum = (size_t) fileSize / sizeof(uint32_t);
         }
-        size_t kmerIdNum = (size_t) fileSize / 4 ;
         cout << "Number of k-mer IDs in info file: " << kmerIdNum << endl;
         if (numOfKmersInDiffIdx != kmerIdNum) {
             cerr << "Error: Number of k-mers in diffIdx file (" << numOfKmersInDiffIdx << ") does not match the number of k-mer IDs in info file (" << kmerIdNum << ")." << endl;

--- a/src/workflow/build.cpp
+++ b/src/workflow/build.cpp
@@ -24,6 +24,7 @@ void setDefaults_build(LocalParameters & par) {
     par.maskProb = 0.9;
     par.maskMode = 1;
     par.accessionLevel = 0;
+    par.packInfo = 1;
     time_t now = time(0);
     tm *ltm = localtime(&now);
     par.dbDate = to_string(1900 + ltm->tm_year) + "-" + to_string(1 + ltm->tm_mon) + "-" + to_string(ltm->tm_mday);

--- a/src/workflow/updateDB.cpp
+++ b/src/workflow/updateDB.cpp
@@ -23,6 +23,7 @@ void setDefaults_updateDB(LocalParameters & par){
     par.maskProb = 0.9;
     par.maskMode = 1;
     par.accessionLevel = 0;
+    par.packInfo = 1;
     // Get current date
     time_t now = time(0);
     tm *ltm = localtime(&now);

--- a/util/simulate_faa_reads.py
+++ b/util/simulate_faa_reads.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+import argparse
+import gzip
+import random
+import sys
+from pathlib import Path
+
+
+def open_text(path):
+    return gzip.open(path, "rt") if str(path).endswith(".gz") else open(path, "r")
+
+
+def parse_fasta(path):
+    name = None
+    chunks = []
+    with open_text(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(">"):
+                if name is not None:
+                    yield name, "".join(chunks)
+                name = line[1:].split()[0]
+                chunks = []
+            else:
+                chunks.append(line)
+        if name is not None:
+            yield name, "".join(chunks)
+
+
+def wrap(seq, width=80):
+    for i in range(0, len(seq), width):
+        yield seq[i:i + width]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Naively simulate amino-acid reads by sampling substrings from .faa files."
+    )
+    parser.add_argument("faa_list", help="Text file with one .faa/.faa.gz path per line.")
+    parser.add_argument("output", help="Output FASTA file for simulated reads.")
+    parser.add_argument("--reads", type=int, default=10000, help="Number of reads to emit.")
+    parser.add_argument("--read-len", type=int, default=100, help="Substring length.")
+    parser.add_argument("--files", type=int, default=100, help="Number of input files to sample.")
+    parser.add_argument("--seed", type=int, default=1, help="Random seed for reproducible output.")
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    with open(args.faa_list) as handle:
+        all_files = [Path(line.strip()) for line in handle
+                     if line.strip() and not line.lstrip().startswith("#")]
+
+    if not all_files:
+        sys.exit("No FASTA files found in the input list.")
+
+    selected_files = rng.sample(all_files, min(args.files, len(all_files)))
+
+    records = []
+    skipped_short = 0
+    for path in selected_files:
+        for name, seq in parse_fasta(path):
+            if len(seq) >= args.read_len:
+                records.append((path, name, seq))
+            else:
+                skipped_short += 1
+
+    if not records:
+        sys.exit(f"No sequences were at least {args.read_len} aa long.")
+
+    with open(args.output, "w") as out:
+        for read_id in range(1, args.reads + 1):
+            path, name, seq = rng.choice(records)
+            start = rng.randint(0, len(seq) - args.read_len)
+            read = seq[start:start + args.read_len]
+            out.write(f">sim_{read_id} source={path.name} seq={name} start={start} len={args.read_len}\n")
+            for line in wrap(read):
+                out.write(line + "\n")
+
+    sys.stderr.write(
+        f"Wrote {args.reads} reads from {len(records)} eligible sequences "
+        f"across {len(selected_files)} files to {args.output}\n"
+    )
+    if skipped_short:
+        sys.stderr.write(f"Skipped {skipped_short} sequences shorter than {args.read_len} aa\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What's New

## Bitpacking, and how it works
I have implemented bitpacking for the TaxID index for Metabuli. The idea is that instead of storing 32 bit raw integers for each metamer, we can bitpack them because the number of unique IDs does not need the complete range of the 32bits. The current implementation can pack based on several cases (8, 10, 12, 16 or 21) bits, so depending on what the maximum tax ID, it chooses which level of packing to do.

This implementation basically packs them always into `uint64_t`, for example, if the packing rate is 10, then we put 5 integers in a 64 bit chunk and waste 4 bit, and so on.

This implementation is backward compatible, so if we give Metabuli an old database, it works as intended, it looks at `db.parameters` and if there is no mention about bitpacking, then it assumes it's the original 32 bit integers and continues with a plain buffer. If the `db.parameters` mentions the bitpacking rate, then that is used and a special reader that can return the individual integers from the 64 bit with masking and shifting. For example, for a 12 bit packing, we do something like this:

```c++
constexpr uint8_t ID_BITS = 12;
constexpr uint64_t MASK = (uint64_t{1} << ID_BITS) - 1;  // 0xFFF

uint64_t word = packedWord; // read 64 bits

uint32_t id = (word >> (lane * ID_BITS)) & MASK;  // where ID_BITS is the bitpacking rate and lane is the slot number
```

With this lane concept, we can easily seek a certain element with its index number with 

```c++
size_t wordOffset = logicalOffset / idsPerWord;  // which uint64_t word
size_t lane = logicalOffset % idsPerWord;  // which ID slot inside that word
```

## Compact old Databases subcommand
Also added the subcommand `compact-info` which basically takes an old databases and compacts the `info` index, so we don't need to rebuild the database all over again, we can just compact in place when possible

## Testing
The regression test seems to run. Further, I tested on GTDB release RS80 (it's an old one) which contains around 3000 genomes or so, I built the database with the original Metabuli and the bitpacking one, the resulting info index was around 34% smaller in size, with negligible increase in database building time (around 5% more). For classification, I simulated a million single-end short reads from these genomes and classified them, both version ran in about 16 seconds, therefore, there was no noticible decrease in time after bitpacking the IDs.
